### PR TITLE
The "DocumentUploadEnabled" app setting is now split into 2 new names…

### DIFF
--- a/webapi/Controllers/ServiceInfoController.cs
+++ b/webapi/Controllers/ServiceInfoController.cs
@@ -120,7 +120,8 @@ public class ServiceInfoController : ControllerBase
             HeaderIcon = this._frontendOptions.HeaderIcon,
             HeaderSettingsEnabled = this._frontendOptions.HeaderSettingsEnabled,
             HeaderPluginsEnabled = this._frontendOptions.HeaderPluginsEnabled,
-            DocumentUploadEnabled = this._frontendOptions.DocumentUploadEnabled,
+            DocumentLocalUploadEnabled = this._frontendOptions.DocumentLocalUploadEnabled,
+            DocumentGlobalUploadEnabled = this._frontendOptions.DocumentGlobalUploadEnabled,
             CreateNewChat = this._frontendOptions.CreateNewChat,
             DisclaimerMsg = this._frontendOptions.DisclaimerMsg
         };

--- a/webapi/Models/FrontendConfig.cs
+++ b/webapi/Models/FrontendConfig.cs
@@ -26,8 +26,10 @@ public class FrontendConfig
   [JsonPropertyName("headerPluginsEnabled")]
   public Boolean HeaderPluginsEnabled { get; set; } = false;
 
-  [JsonPropertyName("documentUploadEnabled")]
-  public Boolean DocumentUploadEnabled { get; set; } = false;
+  [JsonPropertyName("documentLocalUploadEnabled")]
+  public Boolean DocumentLocalUploadEnabled { get; set; } = false;
+  [JsonPropertyName("documentGlobalUploadEnabled")]
+  public Boolean DocumentGlobalUploadEnabled { get; set; } = false;
 
   [JsonPropertyName("createNewChat")]
   public Boolean CreateNewChat { get; set; } = false;

--- a/webapi/Options/FrontendOptions.cs
+++ b/webapi/Options/FrontendOptions.cs
@@ -22,7 +22,8 @@ public sealed class FrontendOptions
     public string HeaderIcon { get; set; } = string.Empty;
     public Boolean HeaderSettingsEnabled { get; set; } = false;
     public Boolean HeaderPluginsEnabled { get; set; } = false;
-    public Boolean DocumentUploadEnabled { get; set; } = false;
+    public Boolean DocumentLocalUploadEnabled { get; set; } = false;
+    public Boolean DocumentGlobalUploadEnabled { get; set; } = false;
     public Boolean CreateNewChat { get; set; } = false;
     public string DisclaimerMsg { get; set; } = string.Empty;
 }

--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -158,7 +158,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
     };
 
     const handleDrop = (e: React.DragEvent<HTMLTextAreaElement>) => {
-        if (store.getState().app.frontendSettings?.documentUploadEnabled != true) {
+        if (store.getState().app.frontendSettings?.documentLocalUploadEnabled != true) {
             return;
         } else {
             onDragLeave(e);
@@ -194,13 +194,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                     disabled={conversations[selectedId].disabled}
                     textarea={{
                         className:
-                            isDraggingOver && store.getState().app.frontendSettings?.documentUploadEnabled == true
+                            isDraggingOver && store.getState().app.frontendSettings?.documentLocalUploadEnabled == true
                                 ? mergeClasses(classes.dragAndDrop, classes.textarea)
                                 : classes.textarea,
                     }}
                     className={classes.input}
                     value={
-                        isDraggingOver && store.getState().app.frontendSettings?.documentUploadEnabled == true
+                        isDraggingOver && store.getState().app.frontendSettings?.documentLocalUploadEnabled == true
                             ? 'Drop your files here'
                             : value
                     }
@@ -219,7 +219,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                         }
                     }}
                     onChange={(_event, data) => {
-                        if (isDraggingOver && store.getState().app.frontendSettings?.documentUploadEnabled == true) {
+                        if (
+                            isDraggingOver &&
+                            store.getState().app.frontendSettings?.documentLocalUploadEnabled == true
+                        ) {
                             return;
                         }
 
@@ -257,7 +260,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                     />
                     <Button
                         disabled={
-                            store.getState().app.frontendSettings?.documentUploadEnabled != true ||
+                            store.getState().app.frontendSettings?.documentLocalUploadEnabled != true ||
                             conversations[selectedId].disabled ||
                             (importingDocuments && importingDocuments.length > 0)
                         }

--- a/webapp/src/components/chat/tabs/DocumentsTab.tsx
+++ b/webapp/src/components/chat/tabs/DocumentsTab.tsx
@@ -138,6 +138,7 @@ export const DocumentsTab: React.FC = () => {
                 {/* Hidden input for file upload. Only accept .txt and .pdf files for now. */}
                 <input
                     type="file"
+                    disabled={store.getState().app.frontendSettings?.documentLocalUploadEnabled != true}
                     ref={localDocumentFileRef}
                     style={{ display: 'none' }}
                     accept={Constants.app.importTypes}
@@ -148,6 +149,7 @@ export const DocumentsTab: React.FC = () => {
                 />
                 <input
                     type="file"
+                    disabled={store.getState().app.frontendSettings?.documentGlobalUploadEnabled != true}
                     ref={globalDocumentFileRef}
                     style={{ display: 'none' }}
                     accept={Constants.app.importTypes}
@@ -163,7 +165,6 @@ export const DocumentsTab: React.FC = () => {
                                 className={classes.uploadButton}
                                 icon={<DocumentArrowUp20Regular />}
                                 disabled={
-                                    store.getState().app.frontendSettings?.documentUploadEnabled != true ||
                                     conversations[selectedId].disabled ||
                                     (importingDocuments && importingDocuments.length > 0)
                                 }
@@ -179,6 +180,7 @@ export const DocumentsTab: React.FC = () => {
                                 onClick={() => localDocumentFileRef.current?.click()}
                                 icon={<Add20 />}
                                 disabled={
+                                    store.getState().app.frontendSettings?.documentLocalUploadEnabled != true ||
                                     conversations[selectedId].disabled ||
                                     (importingDocuments && importingDocuments.length > 0)
                                 }
@@ -190,6 +192,7 @@ export const DocumentsTab: React.FC = () => {
                                 onClick={() => globalDocumentFileRef.current?.click()}
                                 icon={<GlobeAdd20Regular />}
                                 disabled={
+                                    store.getState().app.frontendSettings?.documentGlobalUploadEnabled != true ||
                                     conversations[selectedId].disabled ||
                                     (importingDocuments && importingDocuments.length > 0)
                                 }

--- a/webapp/src/libs/frontend/FrontendHelper.ts
+++ b/webapp/src/libs/frontend/FrontendHelper.ts
@@ -7,7 +7,8 @@ export interface FrontendConfig {
     headerIcon: string;
     headerSettingsEnabled: boolean;
     headerPluginsEnabled: boolean;
-    documentUploadEnabled: boolean;
+    documentLocalUploadEnabled: boolean;
+    documentGlobalUploadEnabled: boolean;
     createNewChat: boolean;
     disclaimerMsg: string;
 }


### PR DESCRIPTION
…: "DocumentLocalUploadEnabled" and "DocumentGlobalUploadEnabled" to control whether the users can upload local, global, both, or none documents.

### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
